### PR TITLE
Add the button for instructors to pin post

### DIFF
--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -161,6 +161,8 @@ TopicObject:
         bookmark:
           nullable: true
           type: number
+        pin:
+          type: boolean
         unreplied:
           type: boolean
         icons:

--- a/public/openapi/read/tags/tag.yaml
+++ b/public/openapi/read/tags/tag.yaml
@@ -209,6 +209,8 @@ get:
                           type: boolean
                         bookmark:
                           nullable: true
+                        pin:
+                          type: boolean
                         unreplied:
                           type: boolean
                         icons:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -73,6 +73,8 @@ get:
                           type: number
                         bookmarks:
                           type: number
+                        pins:
+                          type: number
                         deleterUid:
                           type: number
                         edited:

--- a/public/openapi/read/unread.yaml
+++ b/public/openapi/read/unread.yaml
@@ -178,6 +178,8 @@ get:
                               type: boolean
                             bookmark:
                               nullable: true
+                            pin:
+                              type: boolean
                             unreplied:
                               type: boolean
                             icons:

--- a/public/openapi/write/posts/pid/pin.yaml
+++ b/public/openapi/write/posts/pid/pin.yaml
@@ -1,0 +1,52 @@
+put:
+  tags:
+    - posts
+  summary: pin a post
+  description: This operation pins a post.
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post successfully pinned
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+delete:
+  tags:
+    - posts
+  summary: unpin a post
+  description: This operation unpins a post.
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post successfully unpinned
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -1,6 +1,7 @@
 
 'use strict';
 
+const assert = require('assert');
 
 define('forum/topic/events', [
     'forum/topic/postTools',
@@ -39,6 +40,9 @@ define('forum/topic/events', [
 
         'posts.bookmark': togglePostBookmark,
         'posts.unbookmark': togglePostBookmark,
+
+        'posts.pin': togglePostPin,
+        'posts.unpin': togglePostPin,
 
         'posts.upvote': togglePostVote,
         'posts.downvote': togglePostVote,
@@ -82,6 +86,28 @@ define('forum/topic/events', [
         $('[data-pid="' + data.post.pid + '"] .bookmarkCount').filter(function (index, el) {
             return parseInt($(el).closest('[data-pid]').attr('data-pid'), 10) === parseInt(data.post.pid, 10);
         }).html(data.post.bookmarks).attr('data-bookmarks', data.post.bookmarks);
+    }
+
+    function togglePostPin(data) {
+        // Assert that data is an object
+        assert(typeof data === 'object', 'Expected `data` to be an object');
+        // Assert that data.post is an object
+        assert(typeof data.post === 'object', 'Expected `data.post` to be an object');
+        // Assert that data.post.pid is a string or number
+        assert(typeof data.post.pid === 'string' || typeof data.post.pid === 'number', 'Expected `data.post.pid` to be a string or number');
+        // Assert that data.isPinned is a boolean
+        assert(typeof data.isPinned === 'boolean', 'Expected `data.isPinned` to be a boolean');
+        const el = $('[data-pid="' + data.post.pid + '"] [component="post/pin"]').filter(function (index, el) {
+            return parseInt($(el).closest('[data-pid]').attr('data-pid'), 10) === parseInt(data.post.pid, 10);
+        });
+        if (!el.length) {
+            return;
+        }
+
+        el.attr('data-pinned', data.isPinned);
+
+        el.find('[component="post/pin/on"]').toggleClass('hidden', !data.isPinned);
+        el.find('[component="post/pin/off"]').toggleClass('hidden', data.isPinned);
     }
 
     function onTopicPurged(data) {

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -5,12 +5,13 @@ define('forum/topic/threadTools', [
     'components',
     'translator',
     'handleBack',
+    'handleBackPin',
     'forum/topic/posts',
     'api',
     'hooks',
     'bootbox',
     'alerts',
-], function (components, translator, handleBack, posts, api, hooks, bootbox, alerts) {
+], function (components, translator, handleBack, handleBackPin, posts, api, hooks, bootbox, alerts) {
     const ThreadTools = {};
 
     ThreadTools.init = function (tid, topicContainer) {

--- a/public/src/modules/handleBackPin.js
+++ b/public/src/modules/handleBackPin.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const assert = require('assert');
+
+define('handleBackPin', [
+    'components',
+    'storage',
+    'navigator',
+    'forum/pagination',
+], function (components, storage, navigator, pagination) {
+    const handleBackPin = {};
+    let loadTopicsMethod;
+    /**
+     * Initializes the handleBackPin module.
+     * @param {Function} _loadTopicsMethod - The method to load topics.
+     */
+    handleBackPin.init = function (_loadTopicsMethod) {
+        loadTopicsMethod = _loadTopicsMethod;
+        saveClickedIndex();
+        $(window).off('action:popstate', onBackClicked).on('action:popstate', onBackClicked);
+    };
+
+    handleBackPin.onBackClicked = onBackClicked;
+
+    function saveClickedIndex() {
+        $('[component="category"]').on('click', '[component="topic/header"]', function () {
+            const clickedIndex = $(this).parents('[data-index]').attr('data-index');
+            const windowScrollTop = $(window).scrollTop();
+            assert(typeof clickedIndex === 'string', 'Expected clickedIndex to be a string');
+            $('[component="category/topic"]').each(function (index, el) {
+                if ($(el).offset().top - windowScrollTop > 0) {
+                    storage.setItem('category:pin', $(el).attr('data-index'));
+                    storage.setItem('category:pin:clicked', clickedIndex);
+                    storage.setItem('category:pin:offset', $(el).offset().top - windowScrollTop);
+                    return false;
+                }
+            });
+        });
+    }
+
+    /**
+     * Handles the back click action.
+     * @param {boolean} isMarkedUnread - Indicates if the back action is for unread topics.
+     */
+    function onBackClicked(isMarkedUnread) {
+        assert(typeof isMarkedUnread === 'boolean', 'Expected isMarkedUnread to be a boolean');
+        const highlightUnread = isMarkedUnread && ajaxify.data.template.unread;
+        if (
+            ajaxify.data.template.category ||
+            ajaxify.data.template.recent ||
+            ajaxify.data.template.popular ||
+            highlightUnread
+        ) {
+            let pinIndex = storage.getItem('category:pin');
+            let clickedIndex = storage.getItem('category:pin:clicked');
+
+            storage.removeItem('category:pin');
+            storage.removeItem('category:pin:clicked');
+            if (!utils.isNumber(pinIndex)) {
+                return;
+            }
+
+            pinIndex = Math.max(0, parseInt(pinIndex, 10) || 0);
+            clickedIndex = Math.max(0, parseInt(clickedIndex, 10) || 0);
+
+            if (config.usePagination) {
+                const page = Math.ceil((parseInt(pinIndex, 10) + 1) / config.topicsPerPage);
+                if (parseInt(page, 10) !== ajaxify.data.pagination.currentPage) {
+                    pagination.loadPage(page, function () {
+                        handleBackPin.scrollToTopic(pinIndex, clickedIndex);
+                    });
+                } else {
+                    handleBackPin.scrollToTopic(pinIndex, clickedIndex);
+                }
+            } else {
+                if (pinIndex === 0) {
+                    handleBackPin.scrollToTopic(pinIndex, clickedIndex);
+                    return;
+                }
+
+                $('[component="category"]').empty();
+                loadTopicsMethod(Math.max(0, pinIndex - 1) + 1, function () {
+                    handleBackPin.scrollToTopic(pinIndex, clickedIndex);
+                });
+            }
+        }
+    }
+
+    /**
+     * Highlights a topic.
+     * @param {number} topicIndex - The index of the topic to highlight.
+     */
+    handleBackPin.highlightTopic = function (topicIndex) {
+        assert(typeof topicIndex === 'number', 'Expected topicIndex to be a number');
+        const highlight = components.get('category/topic', 'index', topicIndex);
+
+        if (highlight.length && !highlight.hasClass('highlight')) {
+            highlight.addClass('highlight');
+            setTimeout(function () {
+                highlight.removeClass('highlight');
+            }, 5000);
+        }
+    };
+
+    /**
+     * Scrolls to a specific topic.
+     * @param {number} pinIndex - The index of the pinned topic.
+     * @param {number} clickedIndex - The index of the clicked topic.
+     */
+    handleBackPin.scrollToTopic = function (pinIndex, clickedIndex) {
+        assert(typeof pinIndex === 'number', 'Expected pinIndex to be a number');
+        assert(typeof clickedIndex === 'number', 'Expected clickedIndex to be a number');
+        if (!utils.isNumber(pinIndex)) {
+            return;
+        }
+
+        const scrollTo = components.get('category/topic', 'index', pinIndex);
+
+        if (scrollTo.length) {
+            const offset = storage.getItem('category:pin:offset');
+            storage.removeItem('category:pin:offset');
+            $(window).scrollTop(scrollTo.offset().top - offset);
+            handleBackPin.highlightTopic(clickedIndex);
+            navigator.update();
+        }
+    };
+
+    return handleBackPin;
+});

--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -3,11 +3,12 @@
 define('topicList', [
     'forum/infinitescroll',
     'handleBack',
+    'handleBackPin',
     'topicSelect',
     'categoryFilter',
     'forum/category/tools',
     'hooks',
-], function (infinitescroll, handleBack, topicSelect, categoryFilter, categoryTools, hooks) {
+], function (infinitescroll, handleBack, handleBackPin, topicSelect, categoryFilter, categoryTools, hooks) {
     const TopicList = {};
     let templateName = '';
 

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -3,6 +3,7 @@
 const validator = require('validator');
 const _ = require('lodash');
 
+const assert = require('assert');
 const utils = require('../utils');
 const user = require('../user');
 const posts = require('../posts');
@@ -271,6 +272,38 @@ postsAPI.bookmark = async function (caller, data) {
 
 postsAPI.unbookmark = async function (caller, data) {
     return await apiHelpers.postCommand(caller, 'unbookmark', 'bookmarked', '', data);
+};
+
+/**
+ * Pins a post.
+ * @param {Object} caller - The user or system making the API call.
+ * @param {Object} data - The data associated with the pinning action.
+ * @returns {Promise<Object>} A promise that resolves with the result of the pinning action.
+ */
+postsAPI.pin = async function (caller, data) {
+    // Assert that caller and data are objects
+    assert(typeof caller === 'object', 'caller must be an object');
+    assert(typeof data === 'object', 'data must be an object');
+    const result = await apiHelpers.postCommand(caller, 'pin', 'pinned', '', data);
+    // Assert that the result is an object
+    assert(typeof result === 'object', 'Expected the result to be an object');
+    return result;
+};
+
+/**
+ * Unpins a post.
+ * @param {Object} caller - The user or system making the API call.
+ * @param {Object} data - The data associated with the unpinning action.
+ * @returns {Promise<Object>} A promise that resolves with the result of the unpinning action.
+ */
+postsAPI.unpin = async function (caller, data) {
+    // Assert that caller and data are objects
+    assert(typeof caller === 'object', 'caller must be an object');
+    assert(typeof data === 'object', 'data must be an object');
+    const result = await apiHelpers.postCommand(caller, 'unpinned', 'pinned', '', data);
+    // Assert that the result is an object
+    assert(typeof result === 'object', 'Expected the result to be an object');
+    return result;
 };
 
 async function diffsPrivilegeCheck(pid, uid) {

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const posts = require('../../posts');
 const privileges = require('../../privileges');
 
@@ -80,6 +81,38 @@ Posts.bookmark = async (req, res) => {
 Posts.unbookmark = async (req, res) => {
     const data = await mock(req);
     await api.posts.unbookmark(req, data);
+    helpers.formatApiResponse(200, res);
+};
+
+/**
+ * Pins a post.
+ * @param {Object} req - The request object.
+ * @param {Object} res - The response object.
+ * @returns {Promise<void>} - A promise that resolves when the operation is complete.
+ */
+Posts.pin = async (req, res) => {
+    // Assert that req and res are objects
+    assert(typeof req === 'object', 'Expected req to be an object');
+    assert(typeof res === 'object', 'Expected res to be an object');
+    const data = await mock(req);
+    assert(typeof data === 'object', 'Expected data to be an object');
+    await api.posts.pin(req, data);
+    helpers.formatApiResponse(200, res);
+};
+
+/**
+ * Unpins a post.
+ * @param {Object} req - The request object.
+ * @param {Object} res - The response object.
+ * @returns {Promise<void>} - A promise that resolves when the operation is complete.
+ */
+Posts.unpin = async (req, res) => {
+    // Assert that req and res are objects
+    assert(typeof req === 'object', 'Expected req to be an object');
+    assert(typeof res === 'object', 'Expected res to be an object');
+    const data = await mock(req);
+    assert(typeof data === 'object', 'Expected data to be an object');
+    await api.posts.unpin(req, data);
     helpers.formatApiResponse(200, res);
 };
 

--- a/src/posts/pins.js
+++ b/src/posts/pins.js
@@ -1,0 +1,81 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const db = require("../database");
+const plugins = require("../plugins");
+function default_1(Posts) {
+    function togglePin(type, pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (parseInt(uid, 10) <= 0) {
+                throw new Error('[[error:not-logged-in]]');
+            }
+            const isPinning = type === 'pin';
+            const [postData, hasPinned] = yield Promise.all([
+                Posts.getPostFields(pid, ['pid', 'uid']),
+                Posts.hasPinned(pid, uid),
+            ]);
+            if (isPinning && hasPinned) {
+                throw new Error('[[error:already-pinned]]');
+            }
+            if (!isPinning && !hasPinned) {
+                throw new Error('[[error:already-unpinned]]');
+            }
+            if (isPinning) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield db.sortedSetAdd(`uid:${uid}:pins`, Date.now(), pid);
+            }
+            else {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield db.sortedSetRemove(`uid:${uid}:pins`, pid);
+            }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield db[isPinning ? 'setAdd' : 'setRemove'](`pid:${pid}:users_pinned`, uid);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            postData.pins = (yield db.setCount(`pid:${pid}:users_pinned`));
+            yield Posts.setPostField(pid, 'pins', postData.pins);
+            plugins.hooks.fire(`action:post.${type}`, {
+                pid: pid,
+                uid: uid,
+                owner: postData.uid,
+                current: hasPinned ? 'pinned' : 'unpinned',
+            });
+            return {
+                post: postData,
+                isPinned: isPinning,
+            };
+        });
+    }
+    Posts.pin = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield togglePin('pin', pid, uid);
+        });
+    };
+    Posts.unpin = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield togglePin('unpin', pid, uid);
+        });
+    };
+    Posts.hasPinned = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (parseInt(uid, 10) <= 0) {
+                return Array.isArray(pid) ? pid.map(() => false) : false;
+            }
+            if (Array.isArray(pid)) {
+                const sets = pid.map(pid => `pid:${pid}:users_pinned`);
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                return yield db.isMemberOfSets(sets, uid);
+            }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            return yield db.isSetMember(`pid:${pid}:users_pinned`, uid);
+        });
+    };
+}
+exports.default = default_1;

--- a/src/posts/pins.ts
+++ b/src/posts/pins.ts
@@ -1,0 +1,85 @@
+import db = require('../database');
+import plugins = require('../plugins');
+
+type PostData = {
+  uid: string;
+  pins: string[];
+}
+
+type Post = {
+  pin: (pid: string, uid: string) => Promise<unknown>;
+  unpin: (pid: string, uid: string) => Promise<unknown>
+  getPostFields: (pid: string, fields: string[]) => PostData;
+  hasPinned: (pid: string, uid: string) => Promise<unknown>;
+  setPostField: (pid: string, field: string, pins: string[]) => Promise<unknown>;
+}
+
+export default function (Posts: Post) {
+    async function togglePin(type: string, pid: string, uid: string) {
+        if (parseInt(uid, 10) <= 0) {
+            throw new Error('[[error:not-logged-in]]');
+        }
+
+        const isPinning = type === 'pin';
+
+        const [postData, hasPinned] = await Promise.all([
+            Posts.getPostFields(pid, ['pid', 'uid']),
+            Posts.hasPinned(pid, uid),
+        ]);
+
+        if (isPinning && hasPinned) {
+            throw new Error('[[error:already-pinned]]');
+        }
+
+        if (!isPinning && !hasPinned) {
+            throw new Error('[[error:already-unpinned]]');
+        }
+
+        if (isPinning) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await db.sortedSetAdd(`uid:${uid}:pins`, Date.now(), pid);
+        } else {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await db.sortedSetRemove(`uid:${uid}:pins`, pid);
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db[isPinning ? 'setAdd' : 'setRemove'](`pid:${pid}:users_pinned`, uid);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        postData.pins = await db.setCount(`pid:${pid}:users_pinned`) as string[];
+        await Posts.setPostField(pid, 'pins', postData.pins);
+
+        plugins.hooks.fire(`action:post.${type}`, {
+            pid: pid,
+            uid: uid,
+            owner: postData.uid,
+            current: hasPinned ? 'pinned' : 'unpinned',
+        }) as void;
+
+        return {
+            post: postData,
+            isPinned: isPinning,
+        };
+    }
+
+    Posts.pin = async function (pid: string, uid: string) {
+        return await togglePin('pin', pid, uid);
+    };
+
+    Posts.unpin = async function (pid: string, uid: string) {
+        return await togglePin('unpin', pid, uid);
+    };
+
+    Posts.hasPinned = async function (pid: string, uid: string) {
+        if (parseInt(uid, 10) <= 0) {
+            return Array.isArray(pid) ? pid.map(() => false) : false;
+        }
+
+        if (Array.isArray(pid)) {
+            const sets = pid.map(pid => `pid:${pid as string}:users_pinned`);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            return await db.isMemberOfSets(sets, uid) as boolean;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return await db.isSetMember(`pid:${pid}:users_pinned`, uid) as boolean;
+    };
+}

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -85,6 +85,18 @@
     </li>
     {{{ end }}}
 
+    {{{ if config.loggedIn }}}
+    <li>
+        <a component="post/pin" role="menuitem" tabindex="-1" href="#" data-pinned="{posts.pinned}">
+            <span class="menu-icon">
+                <i component="post/pin/on" class="fa fa-fw fa-thumb-tack <!-- IF !posts.pinned -->hidden<!-- ENDIF !posts.pinned -->"></i>
+                <i component="post/pin/off" class="fa fa-fw fa-thumb-tack fa-rotate-90 <!-- IF posts.pinned -->hidden<!-- ENDIF posts.pinned -->"></i>
+            </span>
+            <span class="pin-text">[[topic:Pin]]</span>&nbsp;
+        </a>
+    </li>
+    {{{ end }}}
+    
     <li>
         <a role="menuitem" tabindex="-1" href="#" data-clipboard-text="{posts.absolute_url}">
             <i class="fa fa-fw fa-link"></i> [[topic:copy-permalink]]


### PR DESCRIPTION
resolves #3 
Effort: 16 hours
Criteria: There is a button attached to posts that can be clicked or unclicked
Progress: Though this issue is frontend, in order to see clear changes when clicking on the button, I also did some backend changes. Currently I modified hundreds of code in both public and src folders with added assertion and typescript translations to the relevant javascript files. And now the website can show a button of pin in the drop down list of both posts and replies for instructor account. Now when clicking on it, it now shows any change due to the lack of changes in the backend code, which is dependent on issue #2 