### PR TITLE
Change background color when pinned state is changed

### DIFF
--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -1,6 +1,9 @@
+
 'use strict';
 
-const { post } = require("jquery");
+// The next line was part of the original code base
+// eslint-disable-next-line no-unused-vars
+const { post } = require('jquery');
 
 
 define('forum/topic/threadTools', [
@@ -331,18 +334,31 @@ define('forum/topic/threadTools', [
         posts.addTopicEvents(data.events);
     };
 
-    // Function to change background color based on pinned state
-    // i'm trying to get it so that it only does the top one
-    // This makes it so that any pinned thread has a yellow background.
-    // The problem is that it makes all remaining threads also yellow.
-    // Also, it only does it temporarily.
-    // I think I need to like move this data so that it is somewhere outside of this
+
+
+    /**
+     * changeBackgroundColor
+     * @brief Takes the element postEl and makes its background color gray.
+     * Current issues:
+     * (1) Makes the entire thread have the background color, not just the top
+     * message. I think this is fine though since the eventual goal is to give
+     * specific posts the pinned characteristic.
+     * (2) Changes are temporary. Refreshing the page, exiting and coming back,
+     * all remove the changes. Maybe moving this function call somewhere else?
+     * @param {*} postEl
+     * @param {*} pinned
+     */
 
     function changeBackgroundColor(postEl, pinned) {
+        /** Type Sanity Checks  */
+        console.assert(typeof pinned === 'boolean', 'pinned should be of type boolean');
+        console.assert(typeof postEl === 'object', 'postEl should be an object');
+
         if (pinned) {
-            postEl.css('background-color', 'yellow'); // Change the background color to yellow for pinned posts
+            postEl.css('background-color', '#B3CBB9');
         } else {
-            postEl.css('background-color', ''); // Reset background color for unpinned posts
+            // Reset background color for unpinned posts
+            postEl.css('background-color', '');
         }
     }
 
@@ -352,6 +368,7 @@ define('forum/topic/threadTools', [
             return;
         }
 
+        /** New Call to changeBackgroundColor when the pinState is set */
         // const postEl = components.get('topic/title'); // will choose only the title
         const postEl = components.get('topic');
         changeBackgroundColor(postEl, data.pinned);

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { post } = require("jquery");
+
 
 define('forum/topic/threadTools', [
     'components',
@@ -329,12 +331,31 @@ define('forum/topic/threadTools', [
         posts.addTopicEvents(data.events);
     };
 
+    // Function to change background color based on pinned state
+    // // i'm trying to get it so that it only does the top one
+    // // This makes it so that any pinned thread has a yellow background. The problem is that it makes all remaining threads also yellow. Also, it only does it temporarily. I think I need to like move this data so that it is somewhere outside of this
+
+    function changeBackgroundColor(postEl, pinned) {
+        if (pinned) {
+            postEl.css('background-color', 'yellow'); // Change the background color to yellow for pinned posts
+        } else {
+            postEl.css('background-color', ''); // Reset background color for unpinned posts
+        }
+    }
+
 
     ThreadTools.setPinnedState = function (data) {
         const threadEl = components.get('topic');
         if (parseInt(data.tid, 10) !== parseInt(threadEl.attr('data-tid'), 10)) {
             return;
         }
+
+        // const postEl = components.get('topic/title'); // will choose only the title
+
+        const postEl = components.get('topic');
+        changeBackgroundColor(postEl, data.pinned);
+
+        
 
         components.get('topic/pin').toggleClass('hidden', data.pinned).parent().attr('hidden', data.pinned ? '' : null);
         components.get('topic/unpin').toggleClass('hidden', !data.pinned).parent().attr('hidden', !data.pinned ? '' : null);
@@ -345,11 +366,12 @@ define('forum/topic/threadTools', [
                 data.pinExpiry && data.pinExpiryISO ?
                     '[[topic:pinned-with-expiry, ' + data.pinExpiryISO + ']]' :
                     '[[topic:pinned]]'
+
             ));
         }
         ajaxify.data.pinned = data.pinned;
-
         posts.addTopicEvents(data.events);
+        
     };
 
     function setFollowState(state) {

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -332,8 +332,11 @@ define('forum/topic/threadTools', [
     };
 
     // Function to change background color based on pinned state
-    // // i'm trying to get it so that it only does the top one
-    // // This makes it so that any pinned thread has a yellow background. The problem is that it makes all remaining threads also yellow. Also, it only does it temporarily. I think I need to like move this data so that it is somewhere outside of this
+    // i'm trying to get it so that it only does the top one
+    // This makes it so that any pinned thread has a yellow background.
+    // The problem is that it makes all remaining threads also yellow.
+    // Also, it only does it temporarily.
+    // I think I need to like move this data so that it is somewhere outside of this
 
     function changeBackgroundColor(postEl, pinned) {
         if (pinned) {
@@ -343,7 +346,6 @@ define('forum/topic/threadTools', [
         }
     }
 
-
     ThreadTools.setPinnedState = function (data) {
         const threadEl = components.get('topic');
         if (parseInt(data.tid, 10) !== parseInt(threadEl.attr('data-tid'), 10)) {
@@ -351,11 +353,8 @@ define('forum/topic/threadTools', [
         }
 
         // const postEl = components.get('topic/title'); // will choose only the title
-
         const postEl = components.get('topic');
         changeBackgroundColor(postEl, data.pinned);
-
-        
 
         components.get('topic/pin').toggleClass('hidden', data.pinned).parent().attr('hidden', data.pinned ? '' : null);
         components.get('topic/unpin').toggleClass('hidden', !data.pinned).parent().attr('hidden', !data.pinned ? '' : null);
@@ -371,7 +370,6 @@ define('forum/topic/threadTools', [
         }
         ajaxify.data.pinned = data.pinned;
         posts.addTopicEvents(data.events);
-        
     };
 
     function setFollowState(state) {


### PR DESCRIPTION
Added the function `changeBackgroundColor` which when called in `ThreadTools.setPinnedState` changes the background color when the pinned state is changed. 

Issues: 
(1) Change isn't permanent, immediately goes away after refreshing the page or exiting. Only happens when the pin happens (which makes sense since it's called in `ThreadTools.setPinnedState`). 
(2) Also, it makes the entire thread yellow, not just the top one (but I think that's fine since the goal is to eventually make it so that pinned is a characteristic posts can have not just topics.)