### PR TITLE
Implemented sorting at a lower level than before

### DIFF
--- a/src/posts/bookmarks.js
+++ b/src/posts/bookmarks.js
@@ -5,7 +5,9 @@ const plugins = require('../plugins');
 
 module.exports = function (Posts) {
     Posts.is_important = async function (pid) {
-        return await Posts.getPostField(pid, 'important');
+        // typeof(res) === 'number' or res === null
+        let res = await Posts.getPostField(pid, 'important');
+        return res;
     };
 
     Posts.bookmark = async function (pid, uid) {

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -244,9 +244,10 @@ module.exports = function (Topics) {
             const upvotes = parseInt(postData.upvotes, 10) || 0;
             const downvotes = parseInt(postData.downvotes, 10) || 0;
             const votes = upvotes - downvotes;
+            const important = postData.important;
             await db.sortedSetsAdd([
                 `tid:${tid}:posts`, `tid:${tid}:posts:votes`,
-            ], [postData.timestamp, votes], postData.pid);
+            ], [important === 1 ? 0 : postData.timestamp, important === 1 ? -1 : votes], postData.pid);
         }
         await Topics.increasePostCount(tid);
         await db.sortedSetIncrBy(`tid:${tid}:posters`, 1, postData.uid);
@@ -254,7 +255,6 @@ module.exports = function (Topics) {
         await Topics.setTopicField(tid, 'postercount', posterCount);
         await Topics.updateTeaser(tid);
     };
-
     Topics.removePostFromTopic = async function (tid, postData) {
         await db.sortedSetsRemove([
             `tid:${tid}:posts`,


### PR DESCRIPTION
Previous code for sorting caused a test case to fail. 

The new code cases on whether a post is important and if it is a smaller value is inserted for votes or for timestamp to cause posts to be at the top. 

Resolves #8 .